### PR TITLE
match ppc64le when setting build_linux32

### DIFF
--- a/variables.cmake
+++ b/variables.cmake
@@ -60,7 +60,9 @@ elseif (APPLE)
 else()
     set(LINUX 1)
     execute_process(COMMAND uname -m OUTPUT_VARIABLE machine_uname)
-    if (NOT ${machine_uname} MATCHES "x86_64" AND NOT ${machine_uname} MATCHES "aarch64")
+    if (NOT ${machine_uname} MATCHES "x86_64" AND
+        NOT ${machine_uname} MATCHES "aarch64" AND
+        NOT ${machine_uname} MATCHES "ppc64le")
         set(build_linux32 1)
     endif()
     if (DESKTOP_APP_SPECIAL_TARGET STREQUAL "linux")


### PR DESCRIPTION
@Johnnynator raises a good point, we should problably use CMAKE_SYSTEM_PROCESSOR instead which is a cmake macro