### PR TITLE
Added support of using packaged versions of expected and variant

### DIFF
--- a/external/expected/CMakeLists.txt
+++ b/external/expected/CMakeLists.txt
@@ -7,7 +7,12 @@
 add_library(external_expected INTERFACE IMPORTED GLOBAL)
 add_library(desktop-app::external_expected ALIAS external_expected)
 
-target_include_directories(external_expected SYSTEM
-INTERFACE
-    ${third_party_loc}/expected/include
-)
+if (DESKTOP_APP_USE_PACKAGED_EXPECTED)
+    find_package(tl-expected CONFIG REQUIRED)
+    target_link_libraries(external_expected INTERFACE tl::expected)
+else()
+    target_include_directories(external_expected SYSTEM
+    INTERFACE
+        ${third_party_loc}/expected/include
+    )
+endif()

--- a/external/variant/CMakeLists.txt
+++ b/external/variant/CMakeLists.txt
@@ -7,7 +7,14 @@
 add_library(external_variant INTERFACE IMPORTED GLOBAL)
 add_library(desktop-app::external_variant ALIAS external_variant)
 
-target_include_directories(external_variant SYSTEM
-INTERFACE
-    ${third_party_loc}/variant/include
-)
+if (DESKTOP_APP_USE_PACKAGED_VARIANT)
+    find_path(VARIANT_INCLUDE_DIRS mapbox/variant.hpp)
+    if (NOT VARIANT_INCLUDE_DIRS)
+        message(FATAL_ERROR "Packaged version of mapbox-variant library not found!")
+    endif()
+else()
+    target_include_directories(external_variant SYSTEM
+    INTERFACE
+        ${third_party_loc}/variant/include
+    )
+endif()

--- a/variables.cmake
+++ b/variables.cmake
@@ -24,6 +24,7 @@ endif()
 option(DESKTOP_APP_DISABLE_CRASH_REPORTS "Disable crash report generation." ${DESKTOP_APP_USE_PACKAGED})
 option(DESKTOP_APP_USE_PACKAGED_RLOTTIE "Find rlottie using CMake instead of bundled one." ${DESKTOP_APP_USE_PACKAGED})
 option(DESKTOP_APP_USE_PACKAGED_EXPECTED "Find expected using CMake instead of bundled one." ${DESKTOP_APP_USE_PACKAGED})
+option(DESKTOP_APP_USE_PACKAGED_VARIANT "Find mapbox-variant using CMake instead of bundled one." ${DESKTOP_APP_USE_PACKAGED})
 option(DESKTOP_APP_USE_PACKAGED_FONTS "Use preinstalled fonts instead of bundled one." ${DESKTOP_APP_USE_PACKAGED})
 
 option(DESKTOP_APP_ENABLE_IPO_OPTIMIZATIONS "Enable IPO build optimizations." OFF)

--- a/variables.cmake
+++ b/variables.cmake
@@ -23,6 +23,7 @@ endif()
 
 option(DESKTOP_APP_DISABLE_CRASH_REPORTS "Disable crash report generation." ${DESKTOP_APP_USE_PACKAGED})
 option(DESKTOP_APP_USE_PACKAGED_RLOTTIE "Find rlottie using CMake instead of bundled one." ${DESKTOP_APP_USE_PACKAGED})
+option(DESKTOP_APP_USE_PACKAGED_EXPECTED "Find expected using CMake instead of bundled one." ${DESKTOP_APP_USE_PACKAGED})
 option(DESKTOP_APP_USE_PACKAGED_FONTS "Use preinstalled fonts instead of bundled one." ${DESKTOP_APP_USE_PACKAGED})
 
 option(DESKTOP_APP_ENABLE_IPO_OPTIMIZATIONS "Enable IPO build optimizations." OFF)


### PR DESCRIPTION
Added support of using packaged versions of expected and variant header-only libraries.

Can be disabled by forwarding optional flags.