### PR TITLE
Do not require Wayland client

### DIFF
--- a/external/qt/package.cmake
+++ b/external/qt/package.cmake
@@ -24,7 +24,7 @@ find_package(Qt5 COMPONENTS Core Gui Widgets Network REQUIRED)
 find_package(Qt5Gui COMPONENTS QWebpPlugin REQUIRED)
 
 if (LINUX)
-    find_package(Qt5 COMPONENTS WaylandClient REQUIRED)
+    find_package(Qt5 COMPONENTS WaylandClient)
     find_package(Qt5 OPTIONAL_COMPONENTS XkbCommonSupport QUIET)
 
     if (NOT DESKTOP_APP_USE_PACKAGED)


### PR DESCRIPTION
Although, this shows a warning message like the following if Qt5WaylandClient is not found, the fix does not block build without Wayland headers.

```
Version: 2.2
-- Could NOT find Qt5WaylandClient (missing: Qt5WaylandClient_DIR)
CMake Warning at cmake/external/qt/package.cmake:27 (find_package):
  Found package configuration file:

    /usr/lib/i386-gnu/cmake/Qt5/Qt5Config.cmake

  but it set Qt5_FOUND to FALSE so package "Qt5" is considered to be NOT
  FOUND.  Reason given by package:

  Failed to find Qt5 component "WaylandClient" config file at
  "/usr/lib/i386-gnu/cmake/Qt5WaylandClient/Qt5WaylandClientConfig.cmake"

  

Call Stack (most recent call first):
  CMakeLists.txt:37 (include)


-- Checking for module 'wayland-client'
--   No package 'wayland-client' found
-- Configuring done
-- Generating done
-- Build files have been written to: /srv/extra/telegram-desktop-2.2.0+ds/obj-i686-gnu
```
