### PR TITLE
Do not enforce NDEBUG macro

### DIFF
--- a/options.cmake
+++ b/options.cmake
@@ -9,7 +9,7 @@ add_library(desktop-app::common_options ALIAS common_options)
 
 target_compile_definitions(common_options
 INTERFACE
-    $<IF:$<CONFIG:Debug>,_DEBUG,NDEBUG>
+    $<$<CONFIG:Debug>:_DEBUG>
     QT_NO_KEYWORDS
     QT_NO_CAST_FROM_BYTEARRAY
 )


### PR DESCRIPTION
It affects WebRTC classes which may vary their size that eventually leads to memory corruption and crashes. CMake already [defines](https://gitlab.kitware.com/cmake/cmake/-/blob/1dde7e350a45638f2154430877a530968708448a/Modules/Compiler/GNU.cmake#L55-59) the macro for production build types. One can use a custom build type which does not imply NDEBUG. Please note, tg_owt and tdesktop still must be build with the same CMAKE_BUILD_TYPE.