### PR TITLE
More targeted definition of DESKTOP_APP_USE_PACKAGED_RLOTTIE macro

### DIFF
--- a/external/rlottie/CMakeLists.txt
+++ b/external/rlottie/CMakeLists.txt
@@ -22,7 +22,12 @@ if (DESKTOP_APP_USE_PACKAGED)
     endif()
 endif()
 
-if (NOT rlottie_FOUND AND NOT RLOTTIE_FOUND)
+if (rlottie_FOUND OR RLOTTIE_FOUND)
+    target_compile_definitions(external_rlottie
+    INTERFACE
+        DESKTOP_APP_USE_PACKAGED_RLOTTIE
+    )
+else()
     add_library(external_rlottie_bundled STATIC)
     init_target(external_rlottie_bundled "(external)")
 

--- a/options.cmake
+++ b/options.cmake
@@ -77,13 +77,6 @@ if (DESKTOP_APP_USE_PACKAGED_FONTS)
     )
 endif()
 
-if (rlottie_FOUND OR RLOTTIE_FOUND)
-    target_compile_definitions(common_options
-    INTERFACE
-        DESKTOP_APP_USE_PACKAGED_RLOTTIE
-    )
-endif()
-
 if (NOT DESKTOP_APP_SPECIAL_TARGET STREQUAL "")
     target_compile_definitions(common_options
     INTERFACE


### PR DESCRIPTION
Exclude it from common options, define it only for necessarily targets.

This should fix an issue with CMakeLists.txt of tdesktop. It [includes][1] options.cmake before the whole submodule and searching for rLottie.

 [1]: https://github.com/telegramdesktop/tdesktop/blob/68be54288c5e01f5457cbde701bc1dae54130a9d/CMakeLists.txt#L35
