### PR TITLE
Require minizip<2.0.0 aka. zlib minizip, not minizip-ng

### DIFF
--- a/external/minizip/CMakeLists.txt
+++ b/external/minizip/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(desktop-app::external_minizip ALIAS external_minizip)
 
 if (DESKTOP_APP_USE_PACKAGED)
     find_package(PkgConfig REQUIRED)
-    pkg_check_modules(MINIZIP IMPORTED_TARGET minizip)
+    pkg_check_modules(MINIZIP IMPORTED_TARGET minizip<2.0.0)
 
     if (MINIZIP_FOUND)
         target_link_libraries(external_minizip INTERFACE PkgConfig::MINIZIP)


### PR DESCRIPTION
Original zlib minizip and newer minizip-ng are ABI incompatible.
tdesktop bundles old zlib minizip, but systems such as OpenBSD ship
minizip-ng as their "minizip" package.

http://zlib.net/ shows 1.2.11 as the latest version as of today.

Require the same major version to prevent detecting minizip-ng as
zlib minizip breaking the build.
