### PR TITLE
qt: Include QWidgets to fix DESKTOP_APP_USE_PACKAGED=ON build

### DIFF
--- a/external/qt/CMakeLists.txt
+++ b/external/qt/CMakeLists.txt
@@ -27,6 +27,7 @@ if (DESKTOP_APP_USE_PACKAGED)
     INTERFACE
         ${Qt5Core_PRIVATE_INCLUDE_DIRS}
         ${Qt5Gui_PRIVATE_INCLUDE_DIRS}
+        ${Qt5Widgets_PRIVATE_INCLUDE_DIRS}
     )
 
     if (Qt5DBus_FOUND)


### PR DESCRIPTION
Fix the tdesktop 3.5.0 release build using Qt5:

```
/usr/ports/pobj/tdesktop-3.5.0/tdesktop-3.5.0-full/Telegram/SourceFiles/platform/linux/main_window_linux.cpp:50:10: fatal error: 'private/qaction_p.h' file not found
```
