### PR TITLE
Replace deprecated -W with explicit -Wextra

### DIFF
--- a/options_linux.cmake
+++ b/options_linux.cmake
@@ -12,7 +12,7 @@ INTERFACE
     $<IF:$<CONFIG:Debug>,,-fno-strict-aliasing>
     -pipe
     -Wall
-    -W
+    -Wextra
     -Wno-unused-parameter
     -Wno-switch
     -Wno-missing-field-initializers

--- a/options_mac.cmake
+++ b/options_mac.cmake
@@ -22,7 +22,7 @@ target_compile_options(common_options
 INTERFACE
     -pipe
     -Wall
-    -W
+    -Wextra
     -fPIE
     $<$<COMPILE_LANGUAGE:OBJC,OBJCXX>:-fobjc-weak>
     -fvisibility-inlines-hidden


### PR DESCRIPTION
`-W` looks odd in build logs, I thought it was a missing warning option...
Turns out this has long been superseeded by `-Wexta`, so use that.
