### PR TITLE
Restore some symbols in linux_wayland_helper

### DIFF
--- a/linux_wayland_helper/linux_wayland_helper.cpp
+++ b/linux_wayland_helper/linux_wayland_helper.cpp
@@ -72,6 +72,7 @@ int (*wl_display_prepare_read_queue)(
 int (*wl_display_flush)(struct wl_display *display);
 void (*wl_display_cancel_read)(struct wl_display *display);
 int (*wl_display_read_events)(struct wl_display *display);
+void (*wl_event_queue_destroy)(struct wl_event_queue *queue);
 int (*wl_display_prepare_read)(struct wl_display *display);
 int (*wl_display_dispatch_pending)(struct wl_display *display);
 struct wl_display *(*wl_display_connect)(const char *name);
@@ -79,6 +80,7 @@ void (*wl_display_disconnect)(struct wl_display *display);
 void *(*wl_proxy_create_wrapper)(void *proxy);
 void (*wl_proxy_wrapper_destroy)(void *proxy_wrapper);
 void (*wl_proxy_set_queue)(struct wl_proxy *proxy, struct wl_event_queue *queue);
+int (*wl_display_roundtrip)(struct wl_display *display);
 struct wl_proxy *(*wl_proxy_marshal_array_constructor)(
 	struct wl_proxy *proxy,
 	uint32_t opcode,
@@ -236,6 +238,7 @@ bool Resolve() {
 			&& LOAD_SYMBOL(client, wl_display_flush)
 			&& LOAD_SYMBOL(client, wl_display_cancel_read)
 			&& LOAD_SYMBOL(client, wl_display_read_events)
+			&& LOAD_SYMBOL(client, wl_event_queue_destroy)
 			&& LOAD_SYMBOL(client, wl_display_prepare_read)
 			&& LOAD_SYMBOL(client, wl_display_dispatch_pending)
 			&& LOAD_SYMBOL(client, wl_display_connect)
@@ -243,6 +246,7 @@ bool Resolve() {
 			&& LOAD_SYMBOL(client, wl_proxy_create_wrapper)
 			&& LOAD_SYMBOL(client, wl_proxy_wrapper_destroy)
 			&& LOAD_SYMBOL(client, wl_proxy_set_queue)
+			&& LOAD_SYMBOL(client, wl_display_roundtrip)
 			&& LOAD_SYMBOL(client, wl_proxy_marshal_array_constructor)
 			&& LOAD_SYMBOL(client, wl_proxy_marshal_array_constructor_versioned)
 			&& LOAD_SYMBOL(client, wl_proxy_get_id)
@@ -424,6 +428,12 @@ int wl_display_read_events(struct wl_display *display) {
 	return W::wl_display_read_events(display);
 }
 
+void wl_event_queue_destroy(struct wl_event_queue *queue) {
+	Expects(W::wl_event_queue_destroy != nullptr);
+
+	W::wl_event_queue_destroy(queue);
+}
+
 int wl_display_prepare_read(struct wl_display *display) {
 	Expects(W::wl_display_prepare_read != nullptr);
 
@@ -468,6 +478,12 @@ void wl_proxy_set_queue(
 	Expects(W::wl_proxy_set_queue != nullptr);
 
 	W::wl_proxy_set_queue(proxy, queue);
+}
+
+int wl_display_roundtrip(struct wl_display *display) {
+	Expects(W::wl_display_roundtrip != nullptr);
+
+	return W::wl_display_roundtrip(display);
 }
 
 struct wl_proxy *wl_proxy_marshal_array_constructor(


### PR DESCRIPTION
They're used in the upcoming Qt 6.4