### PR TITLE
Fix conditions for LTO-related options on Linux

### DIFF
--- a/options_linux.cmake
+++ b/options_linux.cmake
@@ -41,7 +41,7 @@ if (DESKTOP_APP_SPECIAL_TARGET)
     target_link_options(common_options
     INTERFACE
         $<$<NOT:$<CONFIG:Debug>>:-flto=auto>
-        $<$<NOT:$<CONFIG:Debug>>:-fuse-linker-plugin>
+        $<$<NOT:$<CONFIG:Debug>>:-fwhole-program>
     )
 endif()
 
@@ -63,6 +63,17 @@ if (NOT DESKTOP_APP_USE_PACKAGED)
             -nostdlib++
         )
     endif()
+    if (CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+        target_link_options(common_options
+        INTERFACE
+            -fwhole-program
+        )
+    elseif (NOT DESKTOP_APP_SPECIAL_TARGET)
+        target_link_options(common_options
+        INTERFACE
+            -fno-use-linker-plugin
+        )
+    endif()
     target_link_options(common_options
     INTERFACE
         -rdynamic
@@ -77,8 +88,6 @@ if (NOT DESKTOP_APP_USE_PACKAGED OR DESKTOP_APP_SPECIAL_TARGET)
     )
     target_link_options(common_options
     INTERFACE
-        $<$<CONFIG:Debug>:-fno-use-linker-plugin>
-        $<$<NOT:$<CONFIG:Debug>>:-fwhole-program>
         -Wl,-z,relro
         -Wl,-z,now
         # -pie # https://gitlab.gnome.org/GNOME/nautilus/-/issues/1601


### PR DESCRIPTION
Currently LTO seem to be always active even when it's not meant to and LTO seem to be broken in debug build.