### PR TITLE
Fix tdesktop 4.3.4 cld3 bundle build with system protobuf

### DIFF
--- a/external/cld3/CMakeLists.txt
+++ b/external/cld3/CMakeLists.txt
@@ -102,8 +102,12 @@ if (NOT DESKTOP_APP_USE_PACKAGED)
     )
 endif()
 
+target_link_libraries(external_cld3_bundled
+PRIVATE
+    ${protobuf_lib}
+)
+
 target_link_libraries(external_cld3
 INTERFACE
     external_cld3_bundled
-    ${protobuf_lib}
 )


### PR DESCRIPTION
```
.../Telegram/ThirdParty/cld3/build/gen/cld_3/protos/sentence.pb.h:10:10: fatal error: 'google/protobuf/port_def.inc' file not found
#include <google/protobuf/port_def.inc>
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```