### PR TITLE
Ensure executables operating in UTF-8 charset on Windows

### DIFF
--- a/options_win.cmake
+++ b/options_win.cmake
@@ -18,6 +18,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     INTERFACE
         /permissive-
         # /Qspectre
+        /utf-8
         /W1
         /WX
         /MP     # Enable multi process build.


### PR DESCRIPTION
Otherwise Qt assumptions are likely broken