### PR TITLE
Get rid of xcb_xlib dependencies

### DIFF
--- a/external/qt/CMakeLists.txt
+++ b/external/qt/CMakeLists.txt
@@ -208,7 +208,6 @@ else()
         plugins/platforms/${qt_lib_prefix}qxcb
         plugins/tls/${qt_lib_prefix}qopensslbackend
         plugins/xcbglintegrations/${qt_lib_prefix}qxcb-egl-integration
-        plugins/xcbglintegrations/${qt_lib_prefix}qxcb-glx-integration
         plugins/iconengines/${qt_lib_prefix}qsvgicon
         lib/${qt_lib_prefix}Qt${QT_VERSION_MAJOR}XcbQpa
         ${common_qt_libs}
@@ -316,7 +315,6 @@ if (LINUX)
         xkbcommon
         xkbcommon-x11
         xcb-cursor
-        xcb-glx
         xcb-xkb
         xcb-randr
         xcb-icccm
@@ -351,8 +349,6 @@ if (LINUX)
         EGL
         GL
         xcb
-        X11
-        X11-xcb
         glib-2.0
     )
 endif()

--- a/external/qt/qt_static_plugins/qt_static_plugins.cpp
+++ b/external/qt/qt_static_plugins/qt_static_plugins.cpp
@@ -32,7 +32,6 @@ Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin)
 #elif defined Q_OS_UNIX // Q_OS_WIN | Q_OS_MAC
 Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)
 Q_IMPORT_PLUGIN(QXcbEglIntegrationPlugin)
-Q_IMPORT_PLUGIN(QXcbGlxIntegrationPlugin)
 Q_IMPORT_PLUGIN(QComposePlatformInputContextPlugin)
 Q_IMPORT_PLUGIN(QSvgIconPlugin)
 #ifndef DESKTOP_APP_DISABLE_DBUS_INTEGRATION


### PR DESCRIPTION
We can drop this dependency thanks to Qt 6.5.0's xcursor -> xcb-cursor rewrite