### PR TITLE
Fix duplicate main declaration when linking with LLD

### DIFF
--- a/external/cld3/CMakeLists.txt
+++ b/external/cld3/CMakeLists.txt
@@ -80,7 +80,6 @@ PRIVATE
     script_span/generated_entities.cc
     script_span/getonescriptspan.cc
     script_span/getonescriptspan.h
-    script_span/getonescriptspan_test.cc
     script_span/utf8statetable.cc
     script_span/offsetmap.cc
     script_span/text_processing.cc


### PR DESCRIPTION
https://github.com/gentoo/gentoo/blob/master/net-im/telegram-desktop/files/tdesktop-4.4.1-fix-dupe-main-decl.patch
