### PR TITLE
Update library name on Windows

### DIFF
--- a/external/kimageformats/CMakeLists.txt
+++ b/external/kimageformats/CMakeLists.txt
@@ -80,7 +80,7 @@ elseif (WIN32)
     PRIVATE
         ${libs_loc}/libavif/$<IF:$<CONFIG:Debug>,Debug,Release>/avif.lib
         ${libs_loc}/libheif/libheif/$<IF:$<CONFIG:Debug>,Debug,Release>/heif.lib
-        ${libs_loc}/libde265/libde265/$<IF:$<CONFIG:Debug>,Debug,Release>/de265.lib
+        ${libs_loc}/libde265/libde265/$<IF:$<CONFIG:Debug>,Debug,Release>/libde265.lib
         ${libs_loc}/dav1d/builddir-$<IF:$<CONFIG:Debug>,debug,release>/src/libdav1d.a
         ${libs_loc}/libjxl/lib/$<IF:$<CONFIG:Debug>,Debug,Release>/jxl-static.lib
         ${libs_loc}/libjxl/lib/$<IF:$<CONFIG:Debug>,Debug,Release>/jxl_threads-static.lib


### PR DESCRIPTION
Hello,

I'd like to update dav1d, libde265, libheif, libjxl in Windows build. I already built tdesktop locally.

But `de265.lib` changed to `libde265.lib` so I need to change the cmake script.