### PR TITLE
Disable cppgir warnings

### DIFF
--- a/external/glib/generate_cppgir.cmake
+++ b/external/glib/generate_cppgir.cmake
@@ -21,6 +21,8 @@ function(generate_cppgir target_name gir)
         ${gen_timestamp}
     COMMAND
         cppgir
+        --debug
+        1
         --class
         --expected
         --ignore


### PR DESCRIPTION
They're too verbose