### PR TITLE
Added support to equivalent -fcf-protection but for aarch64

### DIFF
--- a/external/dispatch/CMakeLists.txt
+++ b/external/dispatch/CMakeLists.txt
@@ -15,10 +15,18 @@ endif()
 
 if (NOT DESKTOP_APP_DISPATCH_LIBRARIES OR NOT DESKTOP_APP_DISPATCH_INCLUDE_DIRS)
     if (NOT DESKTOP_APP_USE_PACKAGED OR DESKTOP_APP_SPECIAL_TARGET)
+        set(CMAKE_C_FLAGS "-g -pipe -fPIC -fno-omit-frame-pointer -fstack-protector-all -fstack-clash-protection -fcf-protection -D_FORTIFY_SOURCE=3")
+        set(CMAKE_CXX_FLAGS "-g -pipe -fPIC -fno-omit-frame-pointer -fstack-protector-all -fstack-clash-protection -fcf-protection -D_FORTIFY_SOURCE=3")
+
+        if(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+            string(REPLACE "-fcf-protection" "-msign-return-address=all -mbranch-protection=standard" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+            string(REPLACE "-fcf-protection" "-msign-return-address=all -mbranch-protection=standard" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+        endif()
+
         set(dispatch_extra_args
             -DCMAKE_BUILD_TYPE=Release
-            "-DCMAKE_C_FLAGS=-g -pipe -fPIC -fno-omit-frame-pointer -fstack-protector-all -fstack-clash-protection -fcf-protection -D_FORTIFY_SOURCE=3 -D_GLIBCXX_ASSERTIONS"
-            "-DCMAKE_CXX_FLAGS=-g -pipe -fPIC -fno-omit-frame-pointer -fstack-protector-all -fstack-clash-protection -fcf-protection -D_FORTIFY_SOURCE=3 -D_GLIBCXX_ASSERTIONS"
+            "-DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}"
+            "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}"
         )
     elseif (DEFINED CMAKE_BUILD_TYPE)
         set(dispatch_extra_args

--- a/external/jemalloc/CMakeLists.txt
+++ b/external/jemalloc/CMakeLists.txt
@@ -33,13 +33,21 @@ endif()
 include(ProcessorCount)
 ProcessorCount(N)
 
+set(CONFIGURE_COMMAND
+    env
+    "$<IF:$<OR:$<NOT:$<BOOL:${DESKTOP_APP_USE_PACKAGED}>>,$<BOOL:${DESKTOP_APP_SPECIAL_TARGET}>>,EXTRA_CFLAGS=-fno-omit-frame-pointer -fstack-protector-all -fstack-clash-protection -fcf-protection -DNDEBUG -D_FORTIFY_SOURCE=3 -D_GLIBCXX_ASSERTIONS,=>"
+    "$<IF:$<OR:$<NOT:$<BOOL:${DESKTOP_APP_USE_PACKAGED}>>,$<BOOL:${DESKTOP_APP_SPECIAL_TARGET}>>,EXTRA_CXXFLAGS=-fno-omit-frame-pointer -fstack-protector-all -fstack-clash-protection -fcf-protection -DNDEBUG -D_FORTIFY_SOURCE=3 -D_GLIBCXX_ASSERTIONS,=>"
+    ./autogen.sh --disable-shared
+)
+
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+    string(REPLACE "-fcf-protection" "-msign-return-address=all -mbranch-protection=standard" CONFIGURE_COMMAND "${CONFIGURE_COMMAND}")
+endif()
+
 include(ExternalProject)
 ExternalProject_Add(jemalloc
     URL ${third_party_loc}/jemalloc
-    CONFIGURE_COMMAND env
-        "$<IF:$<OR:$<NOT:$<BOOL:${DESKTOP_APP_USE_PACKAGED}>>,$<BOOL:${DESKTOP_APP_SPECIAL_TARGET}>>,EXTRA_CFLAGS=-fno-omit-frame-pointer -fstack-protector-all -fstack-clash-protection -fcf-protection -DNDEBUG -D_FORTIFY_SOURCE=3 -D_GLIBCXX_ASSERTIONS,=>"
-        "$<IF:$<OR:$<NOT:$<BOOL:${DESKTOP_APP_USE_PACKAGED}>>,$<BOOL:${DESKTOP_APP_SPECIAL_TARGET}>>,EXTRA_CXXFLAGS=-fno-omit-frame-pointer -fstack-protector-all -fstack-clash-protection -fcf-protection -DNDEBUG -D_FORTIFY_SOURCE=3 -D_GLIBCXX_ASSERTIONS,=>"
-        ./autogen.sh --disable-shared
+    CONFIGURE_COMMAND ${CONFIGURE_COMMAND}
     BUILD_COMMAND make $<$<NOT:$<EQUAL:${N},0>>:-j${N}>
     BUILD_IN_SOURCE 1
     STEP_TARGETS build

--- a/options_linux.cmake
+++ b/options_linux.cmake
@@ -85,6 +85,10 @@ if (NOT DESKTOP_APP_USE_PACKAGED OR DESKTOP_APP_SPECIAL_TARGET)
         -fstack-clash-protection
         -fcf-protection
     )
+    if (CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+        list(REMOVE_ITEM common_options "-fcf-protection")
+        list(APPEND common_options "-msign-return-address=all" "-mbranch-protection=standard")
+    endif()
     target_link_options(common_options
     INTERFACE
         -Wl,-z,relro


### PR DESCRIPTION
Hi!

I want to compile telegram desktop for aarch64 but this repository has no support for the security measures need by the arch if replacing -fcf-protection by the propper ones.

Please, let me know if you merge this.

Thanks!