### PR TITLE
Revert "Removed warnings about duplicated libraries for Debug build on macOS."

### DIFF
--- a/options_mac.cmake
+++ b/options_mac.cmake
@@ -48,13 +48,6 @@ if (DESKTOP_APP_SPECIAL_TARGET)
     )
 endif()
 
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-    target_link_options_if_exists(common_options
-    INTERFACE
-        -Wl,-no_warn_duplicate_libraries
-    )
-endif()
-
 target_link_frameworks(common_options
 INTERFACE
     Cocoa


### PR DESCRIPTION
This reverts commit 5742caae65e4163e7faec238eb4e3e5c219ad09c.