### PR TITLE
Don't duplicate compile options with target properties

### DIFF
--- a/init_target.cmake
+++ b/init_target.cmake
@@ -23,11 +23,6 @@ function(init_target target_name) # init_target(my_target [cxx_std_..] folder_na
     endforeach()
     target_compile_features(${target_name} PRIVATE ${standard})
     target_link_libraries(${target_name} PRIVATE desktop-app::common_options)
-    set_target_properties(${target_name} PROPERTIES
-        XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_WEAK YES
-        XCODE_ATTRIBUTE_GCC_INLINES_ARE_PRIVATE_EXTERN YES
-        XCODE_ATTRIBUTE_GCC_SYMBOLS_PRIVATE_EXTERN YES
-    )
     if (DESKTOP_APP_USE_PACKAGED)
         get_target_property(target_type ${target_name} TYPE)
         if (QT_FOUND AND LINUX AND target_type STREQUAL "EXECUTABLE")


### PR DESCRIPTION
XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_WEAK: -fobjc-arc
XCODE_ATTRIBUTE_GCC_INLINES_ARE_PRIVATE_EXTERN: -fvisibility-inlines-hidden
XCODE_ATTRIBUTE_GCC_SYMBOLS_PRIVATE_EXTERN: -fvisibility=hidden

Since 872027e466611376db002709ce3db4b6dd432808 and 5c32bf152f7b83d4a8e53366a1531a7305bc6d40