### PR TITLE
Restore XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_WEAK

### DIFF
--- a/init_target.cmake
+++ b/init_target.cmake
@@ -23,6 +23,9 @@ function(init_target target_name) # init_target(my_target [cxx_std_..] folder_na
     endforeach()
     target_compile_features(${target_name} PRIVATE ${standard})
     target_link_libraries(${target_name} PRIVATE desktop-app::common_options)
+    set_target_properties(${target_name} PROPERTIES
+        XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_WEAK YES
+    )
     if (DESKTOP_APP_USE_PACKAGED)
         get_target_property(target_type ${target_name} TYPE)
         if (QT_FOUND AND LINUX AND target_type STREQUAL "EXECUTABLE")


### PR DESCRIPTION
COMPILE_LANGUAGE expression doesn't work with Xcode