### PR TITLE
Don't link Wayland plugins via qt_import_plugins

### DIFF
--- a/init_target.cmake
+++ b/init_target.cmake
@@ -35,12 +35,6 @@ function(init_target target_name) # init_target(my_target [cxx_std_..] folder_na
                 Qt::QComposePlatformInputContextPlugin
                 Qt::QIbusPlatformInputContextPlugin
                 Qt::QXdgDesktopPortalThemePlugin
-                Qt::QWaylandIntegrationPlugin
-                Qt::QWaylandEglPlatformIntegrationPlugin
-                Qt::QWaylandEglClientBufferPlugin
-                Qt::QWaylandXdgShellIntegrationPlugin
-                Qt::QWaylandAdwaitaDecorationPlugin
-                Qt::QWaylandBradientDecorationPlugin
             )
         endif()
     else()


### PR DESCRIPTION
Most of those plugins seem to be linked automatically while platform plugins themselves are supposed to be controlled with QT_QPA_PLATFORMS when building Qt