### PR TITLE
Ensure only needed static plugins are linked

### DIFF
--- a/external/qt/CMakeLists.txt
+++ b/external/qt/CMakeLists.txt
@@ -16,17 +16,35 @@ if (DESKTOP_APP_USE_PACKAGED)
         Qt::CorePrivate
         Qt::Gui
         Qt::GuiPrivate
-        $<TARGET_NAME_IF_EXISTS:Qt::OpenGL>
         Qt::Widgets
         Qt::WidgetsPrivate
-        $<TARGET_NAME_IF_EXISTS:Qt::OpenGLWidgets>
         Qt::Network
         Qt::Svg
-        $<TARGET_NAME_IF_EXISTS:Qt::DBus>
-        $<TARGET_NAME_IF_EXISTS:Qt::Quick>
-        $<TARGET_NAME_IF_EXISTS:Qt::QuickWidgets>
-        $<TARGET_NAME_IF_EXISTS:Qt::WaylandCompositor>
     )
+
+    if (TARGET Qt::OpenGL)
+        target_link_libraries(external_qt INTERFACE Qt::OpenGL)
+    endif()
+
+    if (TARGET Qt::OpenGLWidgets)
+        target_link_libraries(external_qt INTERFACE Qt::OpenGLWidgets)
+    endif()
+
+    if (TARGET Qt::DBus)
+        target_link_libraries(external_qt INTERFACE Qt::DBus)
+    endif()
+
+    if (TARGET Qt::Quick)
+        target_link_libraries(external_qt INTERFACE Qt::Quick)
+    endif()
+
+    if (TARGET Qt::QuickWidgets)
+        target_link_libraries(external_qt INTERFACE Qt::QuickWidgets)
+    endif()
+
+    if (TARGET Qt::WaylandCompositor)
+        target_link_libraries(external_qt INTERFACE Qt::WaylandCompositor)
+    endif()
 
     return()
 endif()

--- a/init_target.cmake
+++ b/init_target.cmake
@@ -28,14 +28,17 @@ function(init_target target_name) # init_target(my_target [cxx_std_..] folder_na
     )
     if (DESKTOP_APP_USE_PACKAGED)
         get_target_property(target_type ${target_name} TYPE)
-        if (QT_FOUND AND LINUX AND target_type STREQUAL "EXECUTABLE")
-            qt_import_plugins(${target_name}
-            INCLUDE
-                Qt::QGtk3ThemePlugin
-                Qt::QComposePlatformInputContextPlugin
-                Qt::QIbusPlatformInputContextPlugin
-                Qt::QXdgDesktopPortalThemePlugin
-            )
+        if (QT_FOUND AND target_type STREQUAL "EXECUTABLE")
+            cmake_language(EVAL CODE "cmake_language(DEFER CALL qt_finalize_target ${target_name})")
+            if (LINUX)
+                qt_import_plugins(${target_name}
+                INCLUDE
+                    Qt::QGtk3ThemePlugin
+                    Qt::QComposePlatformInputContextPlugin
+                    Qt::QIbusPlatformInputContextPlugin
+                    Qt::QXdgDesktopPortalThemePlugin
+                )
+            endif()
         endif()
     else()
         set_target_properties(${target_name} PROPERTIES


### PR DESCRIPTION
This requires using qt_finalize_target and not using generator expressions for Qt targets since qt_finalize_target seem to parse the linked targets