### PR TITLE
enable MSVC security flags

### DIFF
--- a/options_win.cmake
+++ b/options_win.cmake
@@ -27,6 +27,7 @@ INTERFACE
 if (MSVC)
     target_compile_options(common_options
     INTERFACE
+        /guard:cf /sdl # Control Flow Guard and Security Development Lifecycle checks.
         /permissive-
         # /Qspectre
         /utf-8
@@ -62,6 +63,9 @@ if (MSVC)
 
     target_link_options(common_options
     INTERFACE
+        /guard:cf # Control Flow Guard.
+        $<$<NOT:$<BOOL:${build_winarm}>>:/CETCOMPAT> # Control-flow Enforcement Technology (CET) compatible.
+        /DYNAMICBASE
         $<$<CONFIG:Debug>:/NODEFAULTLIB:LIBCMT>
         $<$<AND:$<CONFIG:Debug>,$<BOOL:${build_win64}>>:/DEBUG:FASTLINK>
         $<$<NOT:$<AND:$<CONFIG:Debug>,$<BOOL:${build_win64}>>>:$<IF:$<STREQUAL:$<GENEX_EVAL:$<TARGET_PROPERTY:MSVC_DEBUG_INFORMATION_FORMAT>>,ProgramDatabase>,/DEBUG,/DEBUG:NONE>>


### PR DESCRIPTION
Add /guard:cf and /sdl to compile options, and /guard:cf, /CETCOMPAT, /DYNAMICBASE to link options for Telegram target when building with MSVC. These flags improve control flow guarding, dynamic base relocation, and overall security hardening of the Windows build.