### PR TITLE
Detect installed Visual Studio version for the default generator

### DIFF
--- a/run_cmake.py
+++ b/run_cmake.py
@@ -6,6 +6,35 @@
 
 import sys, os, shutil, subprocess
 
+def resolveVisualStudioGenerator():
+    fallback = 'Visual Studio 17 2022'
+    vswhere = os.environ.get(
+        'ProgramFiles(x86)',
+        'C:\\Program Files (x86)') + '\\Microsoft Visual Studio\\Installer\\vswhere.exe'
+    if not os.path.isfile(vswhere):
+        return fallback
+    try:
+        import json
+        out = subprocess.check_output([
+            vswhere, '-latest', '-prerelease',
+            '-products', '*',
+            '-requires', 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
+            '-format', 'json',
+        ])
+        data = json.loads(out)
+        if not data:
+            return fallback
+        major = int(data[0]['installationVersion'].split('.')[0])
+    except Exception:
+        return fallback
+    if major >= 18:
+        return 'Visual Studio 18 2026'
+    if major >= 17:
+        return 'Visual Studio 17 2022'
+    if major >= 16:
+        return 'Visual Studio 16 2019'
+    return fallback
+
 def run(project, arguments, buildType=''):
     scriptPath = os.path.dirname(os.path.realpath(__file__))
     basePath = scriptPath + '/../out/' + buildType
@@ -23,6 +52,7 @@ def run(project, arguments, buildType=''):
                 explicitGenerator = True
             cmake.append(arg)
     if sys.platform == 'win32' and not explicitGenerator:
+        cmake.append('-G' + resolveVisualStudioGenerator())
         if vsArch == 'x64':
             cmake.append('-Ax64')
             cmake.append('-T v143')


### PR DESCRIPTION
## Summary

`run_cmake.py` does not pass an explicit `-G` to CMake on Windows, so CMake's default generator wins. On a machine where only Visual Studio 2026 (v18) is installed, CMake's default selection picks `Visual Studio 17 2022`, fails to locate a 2022 instance, and configure aborts with:

```
Generator
  Visual Studio 17 2022
could not find specified instance of Visual Studio:
  C:/Program Files/Microsoft Visual Studio/2022/Community
```

This change probes the latest installed Visual Studio via `vswhere.exe` and selects a matching generator:

- VS 18 (2026) -> `Visual Studio 18 2026`
- VS 17 (2022) -> `Visual Studio 17 2022`
- VS 16 (2019) -> `Visual Studio 16 2019`

The `-T v143` platform toolset is untouched — callers continue to use `v143`, which is supported as a side-by-side toolset inside VS 2026.

If `vswhere.exe` is missing or returns no installation, the fallback is `Visual Studio 17 2022`, matching CMake's previous default behavior, so existing CI machines see no change.

The detection only runs when no explicit `-G` was passed by the caller, preserving the existing override path.